### PR TITLE
poetry token set for two repo handles, so users can havea build and a…

### DIFF
--- a/audit-resolve.json
+++ b/audit-resolve.json
@@ -99,6 +99,71 @@
       "decision": "ignore",
       "madeAt": 1718170835839,
       "expiresAt": 1720762813519
+    },
+    "1102898|@actions/github>@octokit/core>@octokit/graphql>@octokit/request>@octokit/request-error>@octokit/plugin-paginate-rest": {
+      "decision": "ignore",
+      "madeAt": 1744075348084,
+      "expiresAt": 1746667334478
+    },
+    "1100563|cross-spawn": {
+      "decision": "ignore",
+      "madeAt": 1744075349176,
+      "expiresAt": 1746667334478
+    },
+    "1102341|esbuild": {
+      "decision": "ignore",
+      "madeAt": 1744075350155,
+      "expiresAt": 1746667334478
+    },
+    "1098681|micromatch": {
+      "decision": "ignore",
+      "madeAt": 1744075351055,
+      "expiresAt": 1746667334478
+    },
+    "1102832|mocha>serialize-javascript": {
+      "decision": "ignore",
+      "madeAt": 1744075352033,
+      "expiresAt": 1746667334478
+    },
+    "1101846|path-to-regexp": {
+      "decision": "ignore",
+      "madeAt": 1744075352967,
+      "expiresAt": 1746667334478
+    },
+    "1101610|undici": {
+      "decision": "ignore",
+      "madeAt": 1744075353958,
+      "expiresAt": 1746667334478
+    },
+    "1102256|@actions/github>@octokit/core>@octokit/graphql>@octokit/request>@octokit/request-error": {
+      "decision": "ignore",
+      "madeAt": 1744075363318,
+      "expiresAt": 1746667355465
+    },
+    "1102256|@octokit/core>@octokit/graphql>@octokit/request>@octokit/request-error": {
+      "decision": "ignore",
+      "madeAt": 1744075363318,
+      "expiresAt": 1746667355465
+    },
+    "1102256|@octokit/graphql>@octokit/request>@octokit/request-error": {
+      "decision": "ignore",
+      "madeAt": 1744075363318,
+      "expiresAt": 1746667355465
+    },
+    "1102896|@actions/github>@octokit/core>@octokit/graphql>@octokit/request>@octokit/request-error": {
+      "decision": "ignore",
+      "madeAt": 1744075364982,
+      "expiresAt": 1746667355465
+    },
+    "1102896|@octokit/core>@octokit/graphql>@octokit/request>@octokit/request-error": {
+      "decision": "ignore",
+      "madeAt": 1744075364982,
+      "expiresAt": 1746667355465
+    },
+    "1102896|@octokit/graphql>@octokit/request>@octokit/request-error": {
+      "decision": "ignore",
+      "madeAt": 1744075364982,
+      "expiresAt": 1746667355465
     }
   },
   "rules": {},

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint": "eslint .",
     "audit": "check-audit",
     "test": "mocha -r ts-node/register src/**/*.spec.ts",
+    "audit-resolve": "resolve-audit",
     "clean": "ts-node ./scripts/clean.ts",
     "esbuild:action": "npm run clean action && ts-node scripts/esbuild.ts action",
     "esbuild:cli": "npm run clean cli && ts-node scripts/esbuild.ts cli",

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,7 @@ async function setPoetryConfig(config: awsCodeArtifactConfig): Promise<void> {
   const token = await getAuthorizationToken(domain, accountId)
 
   execSync(`poetry config http-basic.mondo "aws" "${token}"`)
+  execSync(`poetry config http-basic.mondo-build "aws" "${token}"`)
 
   console.log('Set codeartifact credentials for poetry')
 


### PR DESCRIPTION
… get repo with different endpoint

### What? 

### Why?
When making a repo that gets built with poetry, if you want a dependency to be from the same repo, you have to specify a
/simple version for getting the dependency, this need a separate repo entry in the pyproject.toml with a different name, we'll call the build version mondo-build by default from now on
### How?

### Testing?

### Screenshots (Optional/For UI)

### Anything Else?


***
This only needs to be done for feature PR's. We don't want to slow down fixes and small changes. As a rule of thumb if you are changing more than a few files we need to add context as part of out definition of done.
***
